### PR TITLE
Enable fatal_warnings flag to pass through to all synthetic targets

### DIFF
--- a/src/python/trueaccord/pants/scalapb/tasks/scalapb_gen.py
+++ b/src/python/trueaccord/pants/scalapb/tasks/scalapb_gen.py
@@ -117,4 +117,4 @@ class ScalaPBGen(SimpleCodegenTask, NailgunTask):
   @property
   def _copy_target_attributes(self):
     """Propagate the provides attribute to the synthetic java_library() target for publishing."""
-    return ['provides']
+    return ['provides', 'fatal_warnings']


### PR DESCRIPTION
The synthetic java and scala targets that the codegen step creates need to be able to pick up the fatal_warnings flag if using javaConversions on proto2, since those generated java files have deprecation warnings.