### PR TITLE
Changed com.trueaccord.scalapb.ScalaPBC to scalapb.ScalaPBC

### DIFF
--- a/src/python/trueaccord/pants/scalapb/tasks/scalapb_gen.py
+++ b/src/python/trueaccord/pants/scalapb/tasks/scalapb_gen.py
@@ -66,7 +66,7 @@ class ScalaPBGen(SimpleCodegenTask, NailgunTask):
     classpath = self.tool_classpath('scalapbc')
 
     args.extend(sources)
-    main = 'com.trueaccord.scalapb.ScalaPBC'
+    main = 'scalapb.ScalaPBC'
     result = self.runjava(classpath=classpath, main=main, args=args, workunit_name='scalapb-gen')
 
     if result != 0:


### PR DESCRIPTION
The scalapb-pants plugin is currently incompatible with the ```com.thesamet``` artifacts, because it uses the deprecated ```com.trueaccord.scalapb.ScalaPBC``` instead of ```scalapb.ScalaPBC```. Tested in [Beaker](https://github.com/ashwin153/beaker), and compiles with version 0.7.4 of ```com.thesamet``` artifacts.