### PR TITLE
Add sources_globs

### DIFF
--- a/src/python/trueaccord/pants/scalapb/tasks/scalapb_gen.py
+++ b/src/python/trueaccord/pants/scalapb/tasks/scalapb_gen.py
@@ -21,6 +21,9 @@ from trueaccord.pants.scalapb.targets.scalapb_library import ScalaPBLibrary
 
 
 class ScalaPBGen(SimpleCodegenTask, NailgunTask):
+
+  sources_globs = ('**/*',)
+
   def __init__(self, *args, **kwargs):
     super(ScalaPBGen, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
Fix the following deprecation:
```
DeprecationWarning: DEPRECATED: SimpleCodegenTask.find_sources is deprecated.
Subclasses should instead specify sources_globs and sources_exclude_globs.
Class to update: ScalaPBGen_gen_scalapb_gen. find_sources will be removed in
version 1.10.0.dev0.
```