### PR TITLE
Fix fatal warnings deprecation in Pants 1.11

### DIFF
--- a/src/python/trueaccord/pants/scalapb/tasks/scalapb_gen.py
+++ b/src/python/trueaccord/pants/scalapb/tasks/scalapb_gen.py
@@ -120,4 +120,4 @@ class ScalaPBGen(SimpleCodegenTask, NailgunTask):
   @property
   def _copy_target_attributes(self):
     """Propagate the provides attribute to the synthetic java_library() target for publishing."""
-    return ['provides', 'fatal_warnings']
+    return ['provides', 'compiler_option_sets']


### PR DESCRIPTION
```
DeprecationWarning: DEPRECATED: fatal_warnings will be removed in version 1.11.0dev0.
fatal_warnings should be defined as part of the target compiler_option_sets
```